### PR TITLE
Add api to update engagement states in gitlab project. Add api to get…

### DIFF
--- a/src/main/java/com/redhat/labs/lodestar/engagements/repository/EngagementRepository.java
+++ b/src/main/java/com/redhat/labs/lodestar/engagements/repository/EngagementRepository.java
@@ -42,6 +42,22 @@ public class EngagementRepository implements PanacheMongoRepository<Engagement> 
                 .page(pageFilter.getPage(), pageFilter.getPageSize()).list();
     }
 
+    /**
+     *
+     * @param email the email id to match (tech lead, EL or customer contact)
+     * @param engagementIds a list of engagement ids that the user has participated in (from participant service)
+     * @return A list of engagements that include the email or engagement ids of participant
+     */
+    public List<Engagement> getEngagementsByUser(PageFilter pageFilter, String email, Set<String> engagementIds) {
+        List<Bson> ors = new ArrayList<>();
+
+        ors.add(eq("engagementLeadEmail", email));
+        ors.add(eq("technicalLeadEmail", email));
+        ors.add(eq("customerContactEmail", email));
+        ors.add(in("uuid", engagementIds));
+        return mongoCollection().find(or(ors)).sort(pageFilter.getBsonSort()).skip(pageFilter.getStartAt()).limit(pageFilter.getPageSize()).into(new ArrayList<>());
+    }
+
     public List<Engagement> getEngagements(PageFilter pageFilter, Set<String> regions, Set<String> types) {
         String query = "";
         Map<String, Object> params = new HashMap<>();

--- a/src/main/java/com/redhat/labs/lodestar/engagements/resource/EngagementResource.java
+++ b/src/main/java/com/redhat/labs/lodestar/engagements/resource/EngagementResource.java
@@ -53,6 +53,7 @@ public class EngagementResource {
         }
         return Response.ok(engagements).header(TOTAL_HEADER, total).build(); //no paging yet
     }
+
     @GET
     @Path("inStates")
     public Response getEngagements(@QueryParam("inStates") Set<EngagementState> states) {
@@ -64,7 +65,13 @@ public class EngagementResource {
         return Response.ok(engagements).header(TOTAL_HEADER, total).build();
     }
 
-    
+    @GET
+    @Path("byUser/{email}")
+    public Response getEngagementsForUser(@PathParam("email") String email, @QueryParam("engagementUuids") Set<String> engagementUuids, @BeanParam PageFilter pagingFilter) {
+        List<Engagement> engagements = engagementService.getEngagementsForUser(pagingFilter, email, engagementUuids);
+        return Response.ok(engagements).header(TOTAL_HEADER, engagements.size()).build();
+    }
+
     @GET
     @Path("category/{category}")
     @Operation(summary = "Gets a list of engagements that have use the category input.")
@@ -170,6 +177,7 @@ public class EngagementResource {
         engagementService.updateLastUpdate(cleanUuid);
         return Response.ok().build();
     }
+
     
     @PUT
     @Path("refresh")
@@ -183,6 +191,13 @@ public class EngagementResource {
         }
 
         return Response.ok().header(TOTAL_HEADER, newCount).build();
+    }
+
+    @PUT
+    @Path("refresh/state")
+    public Response updateStatesInGitlab() {
+        engagementService.updateAllEngagementStates();
+        return Response.ok().build();
     }
     
     @GET

--- a/src/main/java/com/redhat/labs/lodestar/engagements/service/EngagementService.java
+++ b/src/main/java/com/redhat/labs/lodestar/engagements/service/EngagementService.java
@@ -109,6 +109,14 @@ public class EngagementService {
         }
     }
 
+    public void updateAllEngagementStates() {
+        LOGGER.debug("Updating all states in gitlab");
+        engagementRepository.findAll().stream().forEach(e -> {
+                e.setCurrentState(e.getState());
+                bus.publish(UPDATE_STATUS, e);
+        });
+    }
+
     public void create(Engagement engagement) {
         if(engagement.getUuid() != null) { //This will not be true as long as we persist in lodestar-backend
             throw new WebApplicationException("UUID cannot be set before create", Status.BAD_REQUEST);
@@ -268,6 +276,10 @@ public class EngagementService {
 
         return filterEngagementsByState(engagements, inStates);
 
+    }
+
+    public List<Engagement> getEngagementsForUser(PageFilter pageFilter, String userEmail, Set<String> engagementUuids) {
+        return engagementRepository.getEngagementsByUser(pageFilter, userEmail, engagementUuids);
     }
 
     public long countEngagements(String input, String category, Set<String> regions, Set<String> types, Set<EngagementState> states) {


### PR DESCRIPTION
### new apis

- refresh/state - will update the state of the engagement based on usual state criteria and will update gitlab
- get engagements by user - gets a list of engagements by email. Also accepts a list of engagement uuids that represent the engagements the user participated. The email will get engagements where the user was tech lead, customer, lead or customer contact